### PR TITLE
config without bind-hostname and bind-port

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -25,10 +25,8 @@ val `akka-sample-sharding-k8s-java` = project
     // These values will be filled in by the k8s StatefulSet and Deployment
     dockerEntrypoint ++= Seq(
       """-DactorSystemName="$AKKA_ACTOR_SYSTEM_NAME"""",
-      """-Dakka.remote.netty.tcp.hostname="$AKKA_REMOTING_LOGICAL_HOST"""",
+      """-Dakka.remote.netty.tcp.hostname="$AKKA_REMOTING_BIND_HOST"""",
       """-Dakka.remote.netty.tcp.port="$AKKA_REMOTING_BIND_PORT"""",
-      """-Dakka.remote.netty.tcp.bind-hostname="$AKKA_REMOTING_BIND_HOST"""",
-      """-Dakka.remote.netty.tcp.bind-port="$AKKA_REMOTING_BIND_PORT"""",
       """-Dakka.cluster.seed-nodes.0="akka.tcp://${AKKA_ACTOR_SYSTEM_NAME}@${AKKA_SEED_NODE_HOST_0}:${AKKA_SEED_NODE_PORT}"""",
       """-Dakka.cluster.seed-nodes.1="akka.tcp://${AKKA_ACTOR_SYSTEM_NAME}@${AKKA_SEED_NODE_HOST_1}:${AKKA_SEED_NODE_PORT}"""",
       """-Dakka.cluster.seed-nodes.2="akka.tcp://${AKKA_ACTOR_SYSTEM_NAME}@${AKKA_SEED_NODE_HOST_2}:${AKKA_SEED_NODE_PORT}"""",

--- a/k8s/sharding-sample-members.yaml
+++ b/k8s/sharding-sample-members.yaml
@@ -33,8 +33,6 @@ spec:
               fieldPath: status.podIP
         - name: AKKA_ACTOR_SYSTEM_NAME
           value: sharding-sample
-        - name: AKKA_REMOTING_LOGICAL_HOST
-          value: "$(POD_IP)"
         - name: AKKA_REMOTING_BIND_HOST
           value: "$(POD_IP)"
         - name: AKKA_REMOTING_BIND_PORT

--- a/k8s/sharding-sample-seeds.yaml
+++ b/k8s/sharding-sample-seeds.yaml
@@ -38,18 +38,16 @@ spec:
           value: sharding-sample
         - name: AKKA_REMOTING_BIND_PORT
           value: '2551'
-        - name: AKKA_REMOTING_LOGICAL_HOST # The name that other pods can look up this pod with
-          value: "$(POD_NAME).seeds-remoting"
-        - name: AKKA_REMOTING_BIND_HOST    # The internal host name of this pod
-          value: "$(POD_NAME)"
+        - name: AKKA_REMOTING_BIND_HOST
+          value: "$(POD_NAME).seeds-remoting.default.svc.cluster.local"
         - name: AKKA_SEED_NODE_PORT
           value: '2551'
         - name: AKKA_SEED_NODE_HOST_0
-          value: sharding-sample-seeds-0.seeds-remoting
+          value: sharding-sample-seeds-0.seeds-remoting.default.svc.cluster.local
         - name: AKKA_SEED_NODE_HOST_1
-          value: sharding-sample-seeds-1.seeds-remoting
+          value: sharding-sample-seeds-1.seeds-remoting.default.svc.cluster.local
         - name: AKKA_SEED_NODE_HOST_2
-          value: sharding-sample-seeds-2.seeds-remoting
+          value: sharding-sample-seeds-2.seeds-remoting.default.svc.cluster.local
         - name: SAMPLE_HTTP_PORT
           value: '8080'
         - name: SAMPLE_HTTP_HOST


### PR DESCRIPTION
I was able to reproduce the stack trace in https://github.com/typesafehub/prod-suite-management-doc/issues/20 - explicitly using the FQDN solved the issue. Maybe the JDK isn't checking the search domains?